### PR TITLE
feat: update katex-rs to 0.3.1 which adds support for chemical equations (\ce)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-katex = "0.3.0"
+katex = "0.3.1"
 clap = "2.33.3"
 mdbook = "0.4.4"
 serde_json = "1.0.59"


### PR DESCRIPTION
https://github.com/xu-cheng/katex-rs/pull/4

Adds support for writing chemical equations
```latex
\ce{C2H6 + O2 -> CO2 + H2O}
```

Thanks for this amazing plugin!!