### PR TITLE
Add Windows binary to the release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,56 @@ on:
 
 jobs:
 
+  windows-binary:
+
+    runs-on: windows-latest
+
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        target: x86_64-pc-windows-gnu # Not msvc because of quickjs-rs dependency
+        override: true
+
+    - name: Setup msys64 and mingw64
+      run: |
+        $Paths = "C:\msys64\mingw64\bin;C:\msys64\usr\bin"
+        echo "$Paths" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "CARGO_BUILD_TARGET=x86_64-pc-windows-gnu" >> $GITHUB_ENV
+
+    - name: Build mdbook-katex
+      run: |
+        cargo build --release --target x86_64-pc-windows-gnu
+
+    - name: Strip mdbook-katex
+      run: |
+        strip target/x86_64-pc-windows-gnu/release/mdbook-katex.exe
+
+    - name: Get the version
+      shell: bash
+      id: tagName
+      run: |
+        VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+        echo "::set-output name=version::$VERSION"
+
+    - name: Create zip
+      run: |
+        $ZIP_PREFIX = "mdbook-katex-v${{ steps.tagName.outputs.version }}"
+        7z a "$ZIP_PREFIX-x86_64-pc-windows-gnu.zip" `
+             "./target/x86_64-pc-windows-gnu/release/mdbook-katex.exe"
+
+    - name: Upload binary artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-gnu.zip
+
   linux-binaries:
 
     strategy:
@@ -99,7 +149,7 @@ jobs:
 
   deploy:
 
-    needs: [linux-binaries, macos-binary]
+    needs: [windows-binary, linux-binaries, macos-binary]
 
     runs-on: ubuntu-latest
 
@@ -135,6 +185,7 @@ jobs:
         files: |
           Cargo.lock
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-apple-darwin.tar.gz
+          mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-gnu.zip
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-katex = "0.3.1"
+katex = "0.3.2"
 clap = "2.33.3"
 mdbook = "0.4.4"
 serde_json = "1.0.59"


### PR DESCRIPTION
This PR adds the missing `Windows` binary for `mdbook-katex`. You can find the the fake release [here](https://github.com/Luni-4/mdbook-katex/releases/tag/v0.2.9)

Thanks in advance for your review! :)