### PR TITLE
Add Automated Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
     name: test-ubuntu
     runs-on: ubuntu-latest
     strategy:
-    matrix:
-    rust:
-      - stable
-      - beta
-      - nightly
-      # mdBook's Minimum Supported Rust Version
-      - 1.45.0
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          # mdBook's Minimum Supported Rust Version
+          - 1.45.0
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-r         target: x86_64-pc-windows-gnu
+          target: x86_64-pc-windows-gnu
           override: true
 
       - name: Setup windows build environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,36 +28,36 @@ jobs:
 
       - run: cargo test
 
-      name: test-macos
-      runs-on: macos-latest
-      steps:
-        - uses: actions/checkout@master
+    name: test-macos
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@master
 
-        - uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-        - run: cargo test
+      - run: cargo test
 
-        name: test-windows
-        runs-on: windows-latest
-        steps:
-          - uses: actions/checkout@master
+    name: test-windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
 
-          - uses: actions-rs/toolchain@v1
-            with:
-              profile: minimal
-              toolchain: stable
-              target: x86_64-pc-windows-gnu
-              override: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+          override: true
 
-          - name: Setup windows build environment
-            run: |
-              $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
-              echo "PATH=${env:PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-              echo "CARGO_BUILD_TARGET=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Setup windows build environment
+        run: |
+          $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
+          echo "PATH=${env:PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CARGO_BUILD_TARGET=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-          - run: cargo test
+      - run: cargo test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: test-ubuntu
+  test-ubuntu:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,7 +27,7 @@ jobs:
 
       - run: cargo test
 
-    name: test-macos
+  test-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
@@ -41,7 +40,7 @@ jobs:
 
       - run: cargo test
 
-    name: test-windows
+  test-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master
@@ -50,7 +49,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: x86_64-pc-windows-gnu
+r         target: x86_64-pc-windows-gnu
           override: true
 
       - name: Setup windows build environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: test-ci
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: test-ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+    matrix:
+    rust:
+      - stable
+      - beta
+      - nightly
+      # mdBook's Minimum Supported Rust Version
+      - 1.45.0
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - run: cargo test
+
+      name: test-macos
+      runs-on: macos-latest
+      steps:
+        - uses: actions/checkout@master
+
+        - uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: stable
+            override: true
+
+        - run: cargo test
+
+        name: test-windows
+        runs-on: windows-latest
+        steps:
+          - uses: actions/checkout@master
+
+          - uses: actions-rs/toolchain@v1
+            with:
+              profile: minimal
+              toolchain: stable
+              target: x86_64-pc-windows-gnu
+              override: true
+
+          - name: Setup windows build environment
+            run: |
+              $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
+              echo "PATH=${env:PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+              echo "CARGO_BUILD_TARGET=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+          - run: cargo test
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,16 @@ jobs:
 
       - run: cargo test
 
+  RustFmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+
+      - run: cargo fmt -- --check


### PR DESCRIPTION
First up: thanks for making this. It really helps with the math formatting in mdBook, not to mention Katex's speed over MathJax.

# What does this PR do?
I added a Github Workflow, which runs `cargo test` on Windows, macOS and Linux whenever a commit is pushed to `master` or someone opens a PR.
It also checks if the code has been formatted with `cargo fmt`

Also, now we can get a shiny build status badge on the `README.md`:
```
![build-status](https://github.com/lzanini/mdbook-katex/actions/workflows/test.yml/badge.svg)
```