### PR TITLE
Fix #11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl KatexProcessor {
     fn load_macros(ctx: &PreprocessorContext) -> HashMap<String, String> {
         // load macros as a HashMap
         let mut map = HashMap::new();
-        if let Some(path) = get_macro_path(&ctx.config) {
+        if let Some(path) = get_macro_path(&ctx.config, &ctx.root) {
             let macro_str = load_as_string(&path);
             for couple in macro_str.split("\n") {
                 // only consider lines starting with a backslash
@@ -136,13 +136,15 @@ impl KatexProcessor {
         result
     }
 }
-pub fn get_macro_path(config: &mdbook::config::Config) -> Option<PathBuf> {
+pub fn get_macro_path(config: &mdbook::config::Config, book_root: &PathBuf) -> Option<PathBuf> {
     match config
         .get_preprocessor("katex")
         .map(|cfg| cfg.get("macros"))
         .flatten()
     {
-        Some(toml::value::Value::String(macros_value)) => Some(PathBuf::from(macros_value)),
+        Some(toml::value::Value::String(macros_value)) => {
+            Some(book_root.join(PathBuf::from(macros_value)))
+        }
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use mdbook::book::{Book, BookItem};
 use mdbook::errors::Error;
@@ -52,16 +52,9 @@ impl KatexProcessor {
     }
 
     fn load_macros(ctx: &PreprocessorContext) -> HashMap<String, String> {
-        // get macros path from context
-        let mut macros_path = None;
-        if let Some(config) = ctx.config.get_preprocessor("katex") {
-            if let Some(toml::value::Value::String(macros_value)) = config.get("macros") {
-                macros_path = Some(Path::new(macros_value));
-            }
-        }
         // load macros as a HashMap
         let mut map = HashMap::new();
-        if let Some(path) = macros_path {
+        if let Some(path) = get_macro_path(&ctx.config) {
             let macro_str = load_as_string(&path);
             for couple in macro_str.split("\n") {
                 // only consider lines starting with a backslash
@@ -141,6 +134,16 @@ impl KatexProcessor {
             current_split = splits.next()
         }
         result
+    }
+}
+pub fn get_macro_path(config: &mdbook::config::Config) -> Option<PathBuf> {
+    match config
+        .get_preprocessor("katex")
+        .map(|cfg| cfg.get("macros"))
+        .flatten()
+    {
+        Some(toml::value::Value::String(macros_value)) => Some(PathBuf::from(macros_value)),
+        _ => None,
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::str::FromStr;
 
 #[test]
 fn test_name() {
@@ -105,4 +106,22 @@ fn test_macros_with_argument() {
     let rendered_content_no_macro =
         preprocessor.process_chapter(&raw_content_no_macro, &inline_opts, &display_opts);
     debug_assert_eq!(rendered_content_macro, rendered_content_no_macro);
+}
+
+#[test]
+fn test_macro_file_loading() {
+    let cfg_str = r#"
+    [book]
+    src = "src"
+
+    [preprocessor.katex]
+    macros = "macros.txt"
+    "#;
+
+    let cfg = mdbook::config::Config::from_str(cfg_str).unwrap();
+
+    debug_assert_eq!(
+        get_macro_path(&cfg, &PathBuf::from("book")),
+        Some(PathBuf::from("book/macros.txt")) // We supply a root, just like the preproccessor context does
+    );
 }


### PR DESCRIPTION
# Issue
#11 was caused by the program using the relative path defined in `book.toml`:
```toml
[preprocessor.katex]
macros = "macros.txt"
```
This will not work if `mdBook` is called from outside the book directory as @str4d reported.

# Solution
This PR fixes #11 by using the `PreprocessorContext`'s `root` field, defined [here](https://docs.rs/mdbook/0.4.10/mdbook/preprocess/struct.PreprocessorContext.html) as:
> The location of the book directory on disk.

so that the macros file is now located by an absolute path:
```rust
book_root.join(PathBuf::from(macros_value))
```

# Refactoring
In order to make a test case for this issue, I had to refactor the part of `load_macros` that locates the macros file into its own helper function: `get_macro_path` and then test it instead of `load_macros`.

This was because, I was not able to mock a `PreprocessorContext` (no public constructor) that `load_macros` needs:
```rust
fn load_macros(ctx: &PreprocessorContext) -> HashMap<String, String>
```
---
Feel free to ask me any questions regarding the changes in this PR