### PR TITLE
Add version to the CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "mdbook-katex"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Lucas Zanini <zanini.lcs@gmail.com>"]
 edition = "2018"
-description = "mdBook preprocessor rendering LaTex equations to HTML."
+description = "mdBook preprocessor rendering LaTeX equations to HTML."
 license = "MIT"
 readme = "README.md"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate katex;
 extern crate toml;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand, crate_version};
 use mdbook::book::Book;
 use mdbook::errors::Error;
 use mdbook::preprocess::{CmdPreprocessor, Preprocessor, PreprocessorContext};
@@ -11,6 +11,7 @@ use std::io::{self, Read};
 
 pub fn make_app() -> App<'static, 'static> {
     App::new("mdbook-katex")
+        .version(crate_version!())
         .about("A preprocessor that renders KaTex equations to HTML.")
         .subcommand(
             SubCommand::with_name("supports")
@@ -64,12 +65,13 @@ fn handle_rendering(ctx: &RenderContext, rend: &dyn Renderer) -> Result<(), Erro
 }
 
 fn main() -> Result<(), Error> {
+    // set up app
+    let matches = make_app().get_matches();
+
     // grab book data from stdin
     let mut book_data = String::new();
     io::stdin().read_to_string(&mut book_data)?;
 
-    // set up app
-    let matches = make_app().get_matches();
     let pre = KatexProcessor;
 
     // determine what behaviour has been requested


### PR DESCRIPTION
`mdbook-katex --version` doesn't work. It was not added to the `clap` App.