### PR TITLE
Add option `include-src` to include math source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ There are also options to configure the behaviour of the preprocessor:
 | :- | :- | :- |
 | `static-css` | `false` | Generates fully static html pages with katex styling |
 | `macros` | `None` | Path to macros file (see [Custom macros](#custom-macros)) |
+| `include-src` | `false` | Append the source code for the rendered math expressions after them |
+
+For example:
+
+```toml
+[preprocessor.katex]
+static-css = false
+include-src = false
+```
 
 ## Custom macros
 
@@ -85,6 +94,19 @@ These macros can then be used in your `.md` files
 
 $$ \grad f(x) \in \R{n}{p} $$
 ```
+
+## Including math source
+
+This option is added so users can have a convenient way to copy the source code of math expressions when they view the book.
+
+When `include-src` is set to `true`, the included math source code is appended to each rendered math expression.
+Math expressions are `span` elements with `class="katex`.
+Appended math source code is wrapped in `span` elements with `class="katex-src"`.
+
+The math source code is included in a minimal fashion, and it is up to the users to write custom CSS and JavaScript to make use of it.
+For more information about adding custom CSS and JavaScript in `mdbook`, see [additional-css and additional-js](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options).
+
+If you need more information about this feature, please check the issues or file a new issue.
 
 ## Caveats
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,11 +55,15 @@ fn test_render_with_macro(
     raw_contents: &[&str],
     macros: HashMap<String, String>,
 ) -> (String, Vec<String>) {
+    test_render_with_cfg(raw_contents, macros, KatexConfig::default())
+}
+
+fn test_render_with_cfg(
+    raw_contents: &[&str],
+    macros: HashMap<String, String>,
+    cfg: KatexConfig,
+) -> (String, Vec<String>) {
     let preprocessor = KatexProcessor;
-    let cfg = KatexConfig {
-        static_css: false,
-        ..KatexConfig::default()
-    };
     let (inline_opts, display_opts) = mock_build_opts(macros, &cfg);
     let build_root = PathBuf::new();
     let build_dir = PathBuf::from("book");
@@ -73,6 +77,7 @@ fn test_render_with_macro(
                 &inline_opts,
                 &display_opts,
                 &stylesheet_header,
+                cfg.include_src,
             )
         })
         .collect();
@@ -209,4 +214,22 @@ fn test_rendering_vmatrix() {
         "<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:2.4em;vertical-align:-0.95em;\"></span><span class=\"minner\"><span class=\"mopen\"><span class=\"delimsizing mult\"><span class=\"vlist-t vlist-t2\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:1.45em;\"><span style=\"top:-3.45em;\"><span class=\"pstrut\" style=\"height:4.4em;\"></span><span style=\"width:0.333em;height:2.400em;\"><svg xmlns=\"http://www.w3.org/2000/svg\" width='0.333em' height='2.400em' viewBox='0 0 333 2400'><path d='M145 15 v585 v1200 v585 c2.667,10,9.667,15,21,15 c10,0,16.667,-5,20,-15 v-585 v-1200 v-585 c-2.667,-10,-9.667,-15,-21,-15 c-10,0,-16.667,5,-20,15z M188 15 H145 v585 v1200 v585 h43z'/></svg></span></span></span><span class=\"vlist-s\">\u{200b}</span></span><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.95em;\"><span></span></span></span></span></span></span><span class=\"mord\"><span class=\"mtable\"><span class=\"col-align-c\"><span class=\"vlist-t vlist-t2\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:1.45em;\"><span style=\"top:-3.61em;\"><span class=\"pstrut\" style=\"height:3em;\"></span><span class=\"mord\"><span class=\"mord mathnormal\">a</span></span></span><span style=\"top:-2.41em;\"><span class=\"pstrut\" style=\"height:3em;\"></span><span class=\"mord\"><span class=\"mord mathnormal\">c</span></span></span></span><span class=\"vlist-s\">\u{200b}</span></span><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.95em;\"><span></span></span></span></span></span><span class=\"arraycolsep\" style=\"width:0.5em;\"></span><span class=\"arraycolsep\" style=\"width:0.5em;\"></span><span class=\"col-align-c\"><span class=\"vlist-t vlist-t2\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:1.45em;\"><span style=\"top:-3.61em;\"><span class=\"pstrut\" style=\"height:3em;\"></span><span class=\"mord\"><span class=\"mord mathnormal\">b</span></span></span><span style=\"top:-2.41em;\"><span class=\"pstrut\" style=\"height:3em;\"></span><span class=\"mord\"><span class=\"mord mathnormal\">d</span></span></span></span><span class=\"vlist-s\">\u{200b}</span></span><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.95em;\"><span></span></span></span></span></span></span></span><span class=\"mclose\"><span class=\"delimsizing mult\"><span class=\"vlist-t vlist-t2\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:1.45em;\"><span style=\"top:-3.45em;\"><span class=\"pstrut\" style=\"height:4.4em;\"></span><span style=\"width:0.333em;height:2.400em;\"><svg xmlns=\"http://www.w3.org/2000/svg\" width='0.333em' height='2.400em' viewBox='0 0 333 2400'><path d='M145 15 v585 v1200 v585 c2.667,10,9.667,15,21,15 c10,0,16.667,-5,20,-15 v-585 v-1200 v-585 c-2.667,-10,-9.667,-15,-21,-15 c-10,0,-16.667,5,-20,15z M188 15 H145 v585 v1200 v585 h43z'/></svg></span></span></span><span class=\"vlist-s\">\u{200b}</span></span><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.95em;\"><span></span></span></span></span></span></span></span></span></span></span></span>",
         rendered_content
     );
+}
+
+#[test]
+fn test_include_src() {
+    let raw_content = r"Define $f(x)$:
+
+$$
+f(x)=x^2
+$$";
+    let (stylesheet_header, rendered_content) = test_render_with_cfg(
+        &[raw_content],
+        HashMap::new(),
+        KatexConfig {
+            include_src: true,
+            ..KatexConfig::default()
+        },
+    );
+    debug_assert_eq!(stylesheet_header + "Define <span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.10764em;\">f</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">x</span><span class=\"mclose\">)</span></span></span></span><span class=\"katex-src\">f(x)</span>:\n\n<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.10764em;\">f</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">x</span><span class=\"mclose\">)</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span><span class=\"mrel\">=</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.8641em;\"></span><span class=\"mord\"><span class=\"mord mathnormal\">x</span><span class=\"msupsub\"><span class=\"vlist-t\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.8641em;\"><span style=\"top:-3.113em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mtight\">2</span></span></span></span></span></span></span></span></span></span></span></span><span class=\"katex-src\">\nf(x)=x^2\n</span>", rendered_content[0]);
 }


### PR DESCRIPTION
Off by default.
When enabled, append the math source code after the rendered math.