### PR TITLE
Parallel processing chapters and strings between delimiters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tokio",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 toml = "0.5"
 reqwest = { version = "0.11", features = ["blocking"] }
 regex = "1.7"
+tokio = { version = "1.23", features = ["rt-multi-thread"] }
 
 [target.'cfg(unix)'.dependencies]
 katex = "0.4.5"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::str::FromStr;
+use tokio::runtime::Runtime;
 
 #[test]
 fn test_name() {
@@ -68,16 +69,17 @@ fn test_render_with_cfg(
     let build_dir = PathBuf::from("book");
     let stylesheet_header_generator = katex_header(&build_root, &build_dir, &cfg).unwrap();
     let stylesheet_header = stylesheet_header_generator("".to_string());
+    let rt = Runtime::new().unwrap();
     let rendered = raw_contents
         .iter()
         .map(|raw_content| {
-            process_chapter(
+            rt.block_on(process_chapter(
                 raw_content,
                 &inline_opts,
                 &display_opts,
                 &stylesheet_header,
                 cfg.include_src,
-            )
+            ))
         })
         .collect();
     (stylesheet_header, rendered)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,10 +74,10 @@ fn test_render_with_cfg(
         .iter()
         .map(|raw_content| {
             rt.block_on(process_chapter(
-                raw_content,
-                &inline_opts,
-                &display_opts,
-                &stylesheet_header,
+                (*raw_content).to_owned(),
+                inline_opts.clone(),
+                display_opts.clone(),
+                stylesheet_header.clone(),
                 cfg.include_src,
             ))
         })

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,7 +63,6 @@ fn test_render_with_cfg(
     macros: HashMap<String, String>,
     cfg: KatexConfig,
 ) -> (String, Vec<String>) {
-    let preprocessor = KatexProcessor;
     let (inline_opts, display_opts) = mock_build_opts(macros, &cfg);
     let build_root = PathBuf::new();
     let build_dir = PathBuf::from("book");
@@ -72,7 +71,7 @@ fn test_render_with_cfg(
     let rendered = raw_contents
         .iter()
         .map(|raw_content| {
-            preprocessor.process_chapter(
+            process_chapter(
                 raw_content,
                 &inline_opts,
                 &display_opts,


### PR DESCRIPTION
- Spawn multiple `tokio` tasks for processing chapters and strings between delimiters.
- Make methods that used to `impl` `KatexProcessor` static.
- Performance gain of about 100%.
- Barely increased binary size (0.1MB).