### PR TITLE
Use 1 split iterator to split while ignoring `\`

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -97,8 +97,9 @@ fn test_rendering_without_math() {
 
 #[test]
 fn test_dollar_escaping() {
-    let (stylesheet_header, rendered_content) = test_render(r"Some text, \$\$ and more text.");
-    let expected_output = stylesheet_header + r"Some text, $$ and more text.";
+    let raw_content = r"Some text, \$\$ and more text.";
+    let (stylesheet_header, rendered_content) = test_render(raw_content);
+    let expected_output = stylesheet_header + raw_content;
     debug_assert_eq!(expected_output, rendered_content);
 }
 


### PR DESCRIPTION
Use iterator `SplitIgnoreEscaped` to split these ignoring the ones prefixed with `\`:
- <code>```</code> to handle code blocks.
- <code>`</code> to handle inline code blocks.
- `$` and `$$` to render math expression.

The rule is simplified to "escape whatever that is prefixed with `\`."

### Notice
This changes the behavior on handling `\$` and `\$$`.
Previously, `\$` was replaced as `$`, `\$$` was not escaped.
Now, both of the above would be preserved as is.