### PR TITLE
Do not support `katex` renderer so no double preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Then, add the following lines to your `book.toml` file
 [output.katex]
 
 [preprocessor.katex]
+renderers = ["html"]
 ```
 
 You can now use `$` and `$$` delimiters for inline and display equations within your `.md` files. If you need a regular dollar symbol, you can escape delimiters with a backslash `\$`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl Preprocessor for KatexProcessor {
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer == "html" || renderer == "katex"
+        renderer == "html" || renderer == "markdown"
     }
 }
 


### PR DESCRIPTION
Fix #33, fix #48.

This prevents the `katex` preprocessor from being used when invoking the `katex` renderer as described in #48.
Therefore, it decreases the `katex` portion of the built time by 50%, in theory.

This requires the user to add one more line to their `book.toml`:

```toml
[output.katex]

[preprocessor.katex]
renderers = ["html"]
```

If they don't, the book would still build but they would see an error:

```shell
Error: The katex preprocessor does not support the 'katex' renderer
```