### PR TITLE
Handle codeblock correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7724808837b77f4b4de9d283820f9d98bcf496d5692934b857a2399d31ff22e6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "autocfg"
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.0.6"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3c9eae0de7bf8e3f904a5e40612b21fb2e2e566456d177809a48b892d24da"
+checksum = "10861370d2ba66b0f5989f83ebf35db6421713fd92351790e7fdd6c36774c56b"
 dependencies = [
  "clap",
 ]
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27874566aca772cb515af4c6e997b5fe2119820bca447689145e39bb734d19a0"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb951f2523a49533003656a72121306b225ec16a49a09dc6b0ba0d6f3ec3c0"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -263,15 +263,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be778b6327031c1c7b61dd2e48124eee5361e6aa76b8de93692f011b08870ab4"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8a2b87662fe5a0a0b38507756ab66aff32638876a0866e5a5fc82ceb07ee49"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.5"
+version = "4.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e4ab33f1213cdc25b5fa45c76881240cfe79284cf2b395e8b9e312a30a2fd"
+checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
 dependencies = [
  "log",
  "pest",
@@ -656,15 +656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -864,11 +855,11 @@ checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.42.0",
@@ -950,9 +941,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libquickjs-sys"
@@ -1181,19 +1172,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opener"
@@ -1207,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.44"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1239,9 +1230,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.79"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1287,9 +1278,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1297,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1307,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1320,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
@@ -1419,9 +1410,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d89e5dba24725ae5678020bf8f1357a9aa7ff10736b551adbcd3f8d17d766f"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1449,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d0f47a940e895261e77dc200d5eadfc6ef644c179c6f5edfc105e3a2292c8"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1566,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -1655,18 +1646,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1675,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8778cc0b528968fe72abec38b5db5a20a70d148116cd9325d2bc5f5180ca3faf"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -1789,9 +1780,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee3a69cd2c7e06684677e5629b3878b253af05e4714964204279c6bc02cf0b"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1890,9 +1881,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2008,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.5"
 regex = "1.7"
-tokio = { version = "1.23", features = ["rt-multi-thread"] }
+tokio = { version = "1.24", features = ["rt-multi-thread"] }
 
 [target.'cfg(unix)'.dependencies]
 katex = "0.4.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,15 +323,18 @@ impl<'a> Scan<'a> {
             }
         }
         loop {
-            let index = self.index
-                + n_back_ticks
-                + self.string[self.index..]
-                    .find(&"`".repeat(n_back_ticks))
-                    .ok_or(())?;
-            self.index = index;
-            match self.bytes.get(index) {
-                Some(byte) if *byte == b'`' => (),
-                _ => break,
+            self.index += self.string[self.index..]
+                .find(&"`".repeat(n_back_ticks))
+                .ok_or(())?
+                + n_back_ticks;
+            if self.get_byte()? == b'`' {
+                // Skip excessive backticks.
+                self.inc();
+                while let b'`' = self.get_byte()? {
+                    self.inc();
+                }
+            } else {
+                break;
             }
         }
         self.process_byte()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,9 +255,9 @@ async fn process_chapter(
     }
 
     if raw_content.len() - 1 > checkpoint {
-        let block = (&raw_content[checkpoint..raw_content.len()]).into();
-        eprintln!("Pushing text: {block}.");
-        rendered_vec.push(block);
+        let text_block = (&raw_content[checkpoint..raw_content.len()]).into();
+        dbg!(&text_block);
+        rendered_vec.push(text_block);
     }
     rendered_vec.join("")
 }
@@ -374,7 +374,7 @@ impl<'a> Scan<'a> {
             }
         }
 
-        Ok(())
+        self.process_byte()
     }
 
     fn process_inline(&mut self) -> Result<(), ()> {
@@ -401,7 +401,7 @@ impl<'a> Scan<'a> {
             }
         }
 
-        Ok(())
+        self.process_byte()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,24 +227,16 @@ async fn process_chapter(
     for event in events {
         match *event {
             Event::Begin(begin) => checkpoint = begin,
-            Event::TextEnd(end) => {
-                let text_block = (&raw_content[checkpoint..end]).into();
-                dbg!(&text_block);
-                rendered_vec.push(text_block);
-            }
+            Event::TextEnd(end) => rendered_vec.push((&raw_content[checkpoint..end]).into()),
             Event::InlineEnd(end) => {
                 let inline_feed = (&raw_content[checkpoint..end]).into();
-                dbg!(&inline_feed);
                 let inline_block = render(inline_feed, inline_opts.clone(), include_src).await;
-                dbg!(&inline_block);
                 rendered_vec.push(inline_block);
                 checkpoint = end;
             }
             Event::BlockEnd(end) => {
                 let block_feed = (&raw_content[checkpoint..end]).into();
-                dbg!(&block_feed);
                 let block = render(block_feed, display_opts.clone(), include_src).await;
-                dbg!(&block);
                 rendered_vec.push(block);
                 checkpoint = end;
             }
@@ -252,9 +244,7 @@ async fn process_chapter(
     }
 
     if raw_content.len() - 1 > checkpoint {
-        let text_block = (&raw_content[checkpoint..raw_content.len()]).into();
-        dbg!(&text_block);
-        rendered_vec.push(text_block);
+        rendered_vec.push((&raw_content[checkpoint..raw_content.len()]).into());
     }
     rendered_vec.join("")
 }
@@ -325,8 +315,8 @@ impl<'a> Scan<'a> {
         let mut n_back_ticks = 1;
         loop {
             let byte = self.get_byte()?;
-            self.inc();
             if byte == b'`' {
+                self.inc();
                 n_back_ticks += 1;
             } else {
                 break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@ use mdbook::utils::fs::path_to_root;
 use tokio::spawn;
 use tokio::task::JoinHandle;
 
-const CODE_BLOCK_DELIMITER: &str = "```";
-const INLINE_CODE_DELIMITER: &str = "`";
 const BLOCK_DELIM: &str = "$$";
 const INLINE_DELIM: &str = "$";
 
@@ -237,8 +235,7 @@ async fn process_chapter(
             Event::InlineEnd(end) => {
                 let inline_feed = (&raw_content[checkpoint..end]).into();
                 dbg!(&inline_feed);
-                let inline_block =
-                    render(inline_feed, true, inline_opts.clone(), include_src).await;
+                let inline_block = render(inline_feed, inline_opts.clone(), include_src).await;
                 dbg!(&inline_block);
                 rendered_vec.push(inline_block);
                 checkpoint = end;
@@ -246,7 +243,7 @@ async fn process_chapter(
             Event::BlockEnd(end) => {
                 let block_feed = (&raw_content[checkpoint..end]).into();
                 dbg!(&block_feed);
-                let block = render(block_feed, true, display_opts.clone(), include_src).await;
+                let block = render(block_feed, display_opts.clone(), include_src).await;
                 dbg!(&block);
                 rendered_vec.push(block);
                 checkpoint = end;
@@ -405,137 +402,28 @@ impl<'a> Scan<'a> {
     }
 }
 
-/// Process a `block` that is either a full code block or not.
-pub async fn process_block(
-    block: &str,
-    outside_code_block: bool,
-    display_opts: &Opts,
-    inline_opts: &Opts,
-    include_src: bool,
-) -> String {
-    let mut rendered_content = String::with_capacity(block.len());
-    if outside_code_block {
-        // Preserve inline code.
-        let mut outside_inline_code = false;
-        for blob in split_ignore_escaped(block, INLINE_CODE_DELIMITER) {
-            outside_inline_code = !outside_inline_code;
-            if outside_inline_code {
-                // render display equations
-                let content = render_between_delimiters(
-                    blob,
-                    "$$".to_owned(),
-                    display_opts.clone(),
-                    include_src,
-                )
-                .await;
-                // render inline equations
-                let content = render_between_delimiters(
-                    content,
-                    "$".to_owned(),
-                    inline_opts.clone(),
-                    include_src,
-                )
-                .await;
-                rendered_content.push_str(&content);
-            } else {
-                rendered_content.push_str(INLINE_CODE_DELIMITER);
-                rendered_content.push_str(&blob);
-                rendered_content.push_str(INLINE_CODE_DELIMITER);
-            }
-        }
-    } else {
-        rendered_content.push_str(CODE_BLOCK_DELIMITER);
-        rendered_content.push_str(block);
-        rendered_content.push_str(CODE_BLOCK_DELIMITER);
-    }
-    rendered_content
-}
-
-// render equations between given delimiters, with specified options
-pub async fn render_between_delimiters(
-    raw_content: String,
-    delimiters: String,
-    opts: Opts,
-    include_src: bool,
-) -> String {
-    let mut inside_delimiters = false;
-    let mut tasks = Vec::new();
-    for item in split_ignore_escaped(&raw_content, &delimiters) {
-        tasks.push(spawn(render(
-            item,
-            inside_delimiters,
-            opts.clone(),
-            include_src,
-        )));
-        inside_delimiters = !inside_delimiters;
-    }
-    let mut rendered_vec = Vec::with_capacity(tasks.len());
-    for task in tasks {
-        rendered_vec.push(task.await.expect("A tokio task panicked."));
-    }
-    rendered_vec.join("")
-}
-
-pub async fn render(
-    item: String,
-    inside_delimiters: bool,
-    opts: Opts,
-    include_src: bool,
-) -> String {
+pub async fn render(item: String, opts: Opts, include_src: bool) -> String {
     let mut rendered_content = String::new();
-    if inside_delimiters {
-        // try to render equation
-        if let Ok(rendered) = katex::render_with_opts(&item, opts) {
-            let rendered = rendered.replace('\n', " ");
-            if include_src {
-                // Wrap around with `data.katex-src` tag.
-                rendered_content.push_str(r#"<data class="katex-src" value=""#);
-                rendered_content.push_str(&item.replace('"', r#"\""#));
-                rendered_content.push_str(r#"">"#);
-                rendered_content.push_str(&rendered);
-                rendered_content.push_str(r"</data>");
-            } else {
-                rendered_content.push_str(&rendered);
-            }
-        // if rendering fails, keep the unrendered equation
+
+    // try to render equation
+    if let Ok(rendered) = katex::render_with_opts(&item, opts) {
+        let rendered = rendered.replace('\n', " ");
+        if include_src {
+            // Wrap around with `data.katex-src` tag.
+            rendered_content.push_str(r#"<data class="katex-src" value=""#);
+            rendered_content.push_str(&item.replace('"', r#"\""#));
+            rendered_content.push_str(r#"">"#);
+            rendered_content.push_str(&rendered);
+            rendered_content.push_str(r"</data>");
         } else {
-            rendered_content.push_str(&item)
+            rendered_content.push_str(&rendered);
         }
-    // outside delimiters
+    // if rendering fails, keep the unrendered equation
     } else {
         rendered_content.push_str(&item)
     }
+
     rendered_content
-}
-
-#[derive(Debug)]
-struct SplitIgnoreEscaped<'a> {
-    naive_split: std::str::Split<'a, &'a str>,
-    separator: &'a str,
-}
-
-impl<'a> Iterator for SplitIgnoreEscaped<'a> {
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut result = String::new();
-        for split in self.naive_split.by_ref() {
-            result.push_str(split);
-            if split.ends_with('\\') {
-                result.push_str(self.separator)
-            } else {
-                return Some(result);
-            }
-        }
-        None
-    }
-}
-
-fn split_ignore_escaped<'a>(string: &'a str, separator: &'a str) -> SplitIgnoreEscaped<'a> {
-    SplitIgnoreEscaped {
-        naive_split: string.split(separator),
-        separator,
-    }
 }
 
 pub fn get_macro_path(root: &Path, macros_path: &Option<String>) -> Option<PathBuf> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -238,3 +238,25 @@ $$";
     );
     debug_assert_eq!(stylesheet_header + "Define <data class=\"katex-src\" value=\"f(x)\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.10764em;\">f</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">x</span><span class=\"mclose\">)</span></span></span></span></data>:\n\n<data class=\"katex-src\" value=\"\nf(x)=x^2\\\\\nx\\in\\R\n\"><span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.10764em;\">f</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">x</span><span class=\"mclose\">)</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span><span class=\"mrel\">=</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.8641em;\"></span><span class=\"mord\"><span class=\"mord mathnormal\">x</span><span class=\"msupsub\"><span class=\"vlist-t\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.8641em;\"><span style=\"top:-3.113em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mtight\">2</span></span></span></span></span></span></span></span></span><span class=\"mspace newline\"></span><span class=\"base\"><span class=\"strut\" style=\"height:0.5782em;vertical-align:-0.0391em;\"></span><span class=\"mord mathnormal\">x</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span><span class=\"mrel\">∈</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.6889em;\"></span><span class=\"mord mathbb\">R</span></span></span></span></span></data>", rendered_content[0]);
 }
+
+#[test]
+fn test_fenced_code() {
+    let raw_content = r"`\` and `` ` `` $\Leftarrow$
+```
+`\` and `` ` ``
+```
+while ` ``` ` and ````` ```` ````` $\Leftarrow$
+``````
+` ``` ` and ````` ```` `````
+``````
+$$
+\Uparrow
+$$";
+    let (stylesheet_header, rendered_content) =
+        test_render_with_cfg(&[raw_content], HashMap::new(), KatexConfig::default());
+    debug_assert_eq!(
+        stylesheet_header +
+        "`\\` and `` ` `` <span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.3669em;\"></span><span class=\"mrel\">⇐</span></span></span></span>\n```\n`\\` and `` ` ``\n```\nwhile ` ``` ` and ````` ```` ````` <span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.3669em;\"></span><span class=\"mrel\">⇐</span></span></span></span>\n``````\n` ``` ` and ````` ```` `````\n``````\n<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.8889em;vertical-align:-0.1944em;\"></span><span class=\"mrel\">⇑</span></span></span></span></span>",
+        rendered_content[0]
+    );
+}


### PR DESCRIPTION
Partially fix #53 except that indented code blocks are still not handled.
Handling code blocks and separating math blocks are now handled in one pass. This method makes it easy to use custom delimiters in the future.