### PR TITLE
Support custom delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The preprocessor supports passing options to the katex-rs crate in order
 to configure its behaviour. These options are specified under the
 `[preprocessor.katex]` directive.
 
-The currently spported arguments are:
+The currently supported arguments are:
 | Argument | Type |
 | :- | :- |
 | [`leqno`](https://katex.org/docs/options.html#:~:text=default-,leqno,-boolean) | `boolean` |
@@ -62,7 +62,9 @@ There are also options to configure the behaviour of the preprocessor:
 | :- | :- | :- |
 | `static-css` | `false` | Generates fully static html pages with katex styling |
 | `macros` | `None` | Path to macros file (see [Custom macros](#custom-macros)) |
-| `include-src` | `false` | Append the source code for the rendered math expressions after them |
+| `include-src` | `false` | Include math expressions source code (See [Including math Source](#including-math-source)) |
+| `block-delimiter` | `{left = "$$", right = "$$"}` | See [Custom delimiter](#custom-delimiter) |
+| `inline-delimiter` | `{left = "$", right = "$"}` | See [Custom delimiter](#custom-delimiter) |
 
 For example:
 
@@ -71,6 +73,8 @@ For example:
 renderers = ["html"]
 static-css = false
 include-src = false
+block-delimiter = {left = "$$", right = "$$"}
+inline-delimiter = {left = "$", right = "$"}
 ```
 
 ## Custom macros
@@ -129,6 +133,20 @@ The math source code is included in a minimal fashion, and it is up to the users
 For more information about adding custom CSS and JavaScript in `mdbook`, see [additional-css and additional-js](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options).
 
 If you need more information about this feature, please check the issues or file a new issue.
+
+## Custom delimiter
+
+To change the delimiters for math expressions, set the `block-delimiter` and `inline-delimiter` under `[preprocessor.katex]`.
+For example, to use `\(`and `\)` for inline math and `\[` and `\]` for math block, set
+
+```toml
+[preprocessor.katex]
+renderers = ["html"]
+block-delimiter = {left = "\\[", right = "\\]"}
+inline-delimiter = {left = "\\(", right = "\\)"}
+```
+
+Notice that the double backslash above are just used to escape `\` in the TOML format.
 
 ## Caveats
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,6 @@ impl Preprocessor for KatexProcessor {
         enforce_config(&ctx.config);
         // parse TOML config
         let cfg = get_config(&ctx.config)?;
-        dbg!(&cfg);
         let (inline_opts, display_opts, extra_opts) = build_opts(ctx, &cfg);
         // get stylesheet header
         let (stylesheet_header, maybe_download_task) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ impl<'a> Scan<'a> {
     }
 
     pub fn run(&mut self) {
-        _ = self.process_byte();
+        while let Ok(()) = self.process_byte() {}
     }
 
     fn get_byte(&self) -> Result<u8, ()> {
@@ -374,21 +374,19 @@ impl<'a> Scan<'a> {
                 }
                 if self.block_delimiter.match_left(&self.bytes[self.index..]) {
                     self.index += self.block_delimiter.left.len();
-                    self.process_delimit(false)
+                    self.process_delimit(false)?;
                 } else if self.inline_delimiter.match_left(&self.bytes[self.index..]) {
                     self.index += self.inline_delimiter.left.len();
-                    self.process_delimit(true)
-                } else {
-                    self.process_byte()
+                    self.process_delimit(true)?;
                 }
             }
             b'\\' => {
                 self.inc();
-                self.process_byte()
             }
-            b'`' => self.process_backtick(),
-            _ => self.process_byte(),
+            b'`' => self.process_backtick()?,
+            _ => (),
         }
+        Ok(())
     }
 
     fn process_backtick(&mut self) -> Result<(), ()> {
@@ -417,7 +415,7 @@ impl<'a> Scan<'a> {
                 break;
             }
         }
-        self.process_byte()
+        Ok(())
     }
 
     fn process_delimit(&mut self, inline: bool) -> Result<(), ()> {
@@ -454,7 +452,7 @@ impl<'a> Scan<'a> {
             }
         }
 
-        self.process_byte()
+        Ok(())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,7 +19,7 @@ fn test_support_html() {
 fn mock_build_opts(
     macros: HashMap<String, String>,
     cfg: &KatexConfig,
-) -> (katex::Opts, katex::Opts) {
+) -> (katex::Opts, katex::Opts, ExtraOpts) {
     let configure_katex_opts = || -> katex::OptsBuilder {
         katex::Opts::builder()
             .leqno(cfg.leqno)
@@ -44,7 +44,10 @@ fn mock_build_opts(
         .macros(macros)
         .build()
         .unwrap();
-    (inline_opts, display_opts)
+    let extra_opts = ExtraOpts {
+        include_src: cfg.include_src,
+    };
+    (inline_opts, display_opts, extra_opts)
 }
 
 fn test_render(raw_content: &str) -> (String, String) {
@@ -64,7 +67,7 @@ fn test_render_with_cfg(
     macros: HashMap<String, String>,
     cfg: KatexConfig,
 ) -> (String, Vec<String>) {
-    let (inline_opts, display_opts) = mock_build_opts(macros, &cfg);
+    let (inline_opts, display_opts, extra_opts) = mock_build_opts(macros, &cfg);
     let build_root = PathBuf::new();
     let build_dir = PathBuf::from("book");
     let rt = Runtime::new().unwrap();
@@ -80,7 +83,7 @@ fn test_render_with_cfg(
                 inline_opts.clone(),
                 display_opts.clone(),
                 stylesheet_header.clone(),
-                cfg.include_src,
+                extra_opts,
             ))
         })
         .collect();
@@ -204,7 +207,7 @@ fn test_katex_rendering_vmatrix() {
         static_css: false,
         ..KatexConfig::default()
     };
-    let (_, display_opts) = mock_build_opts(HashMap::new(), &cfg);
+    let (_, display_opts, _) = mock_build_opts(HashMap::new(), &cfg);
     let _ = katex::render_with_opts(math_expr, display_opts).unwrap();
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -265,3 +265,28 @@ $$";
         rendered_content[0]
     );
 }
+
+#[test]
+fn test_inline_rendering_w_custom_delimiter() {
+    let raw_content = r"These $\(a\times b\) are from
+\[
+\int_0^abdx
+\]";
+    let (stylesheet_header, rendered_content) = test_render_with_cfg(
+        &[raw_content],
+        HashMap::new(),
+        KatexConfig {
+            inline_delimiter: Delimiter {
+                left: r"\(".into(),
+                right: r"\)".into(),
+            },
+            block_delimiter: Delimiter {
+                left: r"\[".into(),
+                right: r"\]".into(),
+            },
+            ..KatexConfig::default()
+        },
+    );
+    let expected_output = stylesheet_header + "These $<span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.6667em;vertical-align:-0.0833em;\"></span><span class=\"mord mathnormal\">a</span><span class=\"mspace\" style=\"margin-right:0.2222em;\"></span><span class=\"mbin\">×</span><span class=\"mspace\" style=\"margin-right:0.2222em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.6944em;\"></span><span class=\"mord mathnormal\">b</span></span></span></span> are from\n<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:2.3262em;vertical-align:-0.9119em;\"></span><span class=\"mop\"><span class=\"mop op-symbol large-op\" style=\"margin-right:0.44445em;position:relative;top:-0.0011em;\">∫</span><span class=\"msupsub\"><span class=\"vlist-t vlist-t2\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:1.4143em;\"><span style=\"top:-1.7881em;margin-left:-0.4445em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mtight\">0</span></span></span><span style=\"top:-3.8129em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mathnormal mtight\">a</span></span></span></span><span class=\"vlist-s\">\u{200b}</span></span><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.9119em;\"><span></span></span></span></span></span></span><span class=\"mspace\" style=\"margin-right:0.1667em;\"></span><span class=\"mord mathnormal\">b</span><span class=\"mord mathnormal\">d</span><span class=\"mord mathnormal\">x</span></span></span></span></span>";
+    debug_assert_eq!(expected_output, rendered_content[0]);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,6 +46,8 @@ fn mock_build_opts(
         .unwrap();
     let extra_opts = ExtraOpts {
         include_src: cfg.include_src,
+        block_delimiter: cfg.block_delimiter.clone(),
+        inline_delimiter: cfg.inline_delimiter.clone(),
     };
     (inline_opts, display_opts, extra_opts)
 }
@@ -83,7 +85,7 @@ fn test_render_with_cfg(
                 inline_opts.clone(),
                 display_opts.clone(),
                 stylesheet_header.clone(),
-                extra_opts,
+                extra_opts.clone(),
             ))
         })
         .collect();


### PR DESCRIPTION
Support custom delimiter via option `block-delimiter` and `inline-delimiter`.
Group these options with `include-src` into struct `ExtraOpts`.
Use loop for `Scan` to avoid stack overflow in debug mode.