### PR TITLE
[release] Cross compile windows GNU build in CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  windows-binary:
+  msvc-windows-binary:
 
     runs-on: windows-latest
 
@@ -48,6 +48,52 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-msvc.zip
+
+  gnu-windows-binary:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install x86_64-pc-windows-gnu
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        target: x86_64-pc-windows-gnu
+        override: true
+
+    - uses: Swatinem/rust-cache@v2
+
+    - uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: |
+          --release
+          --features native-tls-vendored
+          --target x86_64-pc-windows-gnu
+
+    - name: Get the version
+      id: tagName
+      run: |
+        VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+        echo "::set-output name=version::$VERSION"
+
+    - name: Create tar
+      run: |
+        mv target/x86_64-pc-windows-gnu/release/mdbook-katex mdbook-katex
+        TAR_FILE=mdbook-katex-v${{ steps.tagName.outputs.version }}
+        tar -czvf $TAR_FILE-x86_64-pc-windows-gnu.tar.gz \
+                  mdbook-katex
+
+    - name: Upload binary artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: |
+          mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-gnu.tar.gz
+
   gnu-linux-binary:
 
     runs-on: ubuntu-22.04
@@ -132,7 +178,6 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: |
-          Cargo.lock
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
 
   x86_64-macos-binary:
@@ -216,7 +261,7 @@ jobs:
 
   deploy:
 
-    needs: [windows-binary, gnu-linux-binary, musl-linux-binary, x86_64-macos-binary, aarch64-macos-binary]
+    needs: [msvc-windows-binary, gnu-windows-binary, gnu-linux-binary, musl-linux-binary, x86_64-macos-binary, aarch64-macos-binary]
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -295,6 +295,7 @@ jobs:
           mdbook-katex-v${{ steps.tagName.outputs.version }}-aarch64-apple-darwin.tar.gz
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-apple-darwin.tar.gz
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-msvc.zip
+          mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-gnu.zip
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
           mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
       env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,16 +83,16 @@ jobs:
 
     - name: Create tar
       run: |
-        mv target/x86_64-pc-windows-gnu/release/mdbook-katex mdbook-katex
+        mv target/x86_64-pc-windows-gnu/release/mdbook-katex.exe mdbook-katex.exe
         TAR_FILE=mdbook-katex-v${{ steps.tagName.outputs.version }}
-        tar -czvf $TAR_FILE-x86_64-pc-windows-gnu.tar.gz \
-                  mdbook-katex
+        zip $TAR_FILE-x86_64-pc-windows-gnu.zip \
+                  mdbook-katex.exe
 
     - name: Upload binary artifact
       uses: actions/upload-artifact@v2
       with:
         path: |
-          mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-gnu.tar.gz
+          mdbook-katex-v${{ steps.tagName.outputs.version }}-x86_64-pc-windows-gnu.zip
 
   gnu-linux-binary:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,27 @@ jobs:
 
       - run: cargo test
 
+  test-windows-from-ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: |
+            --features native-tls-vendored
+            --target x86_64-pc-windows-gnu
+
   fmt-clippy:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,8 @@ jobs:
           args: |
             --features native-tls-vendored
             --target x86_64-pc-windows-gnu
+            --no-run
+          # Cannot run because not on Windows.
 
   fmt-clippy:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ regex = "1.7"
 tokio = { version = "1.25", features = ["rt-multi-thread"] }
 
 # Remember to modify the tests accordingly if you modify this.
-[target.'cfg(any(target_os = "macos", all(unix, target_arch = "x86_64")))'.dependencies]
+[target.'cfg(any(target_os = "macos", all(unix, target_arch = "x86_64"), all(windows, target_env = "gnu")))'.dependencies]
 katex = "0.4.6"
 
-[target.'cfg(not(any(target_os = "macos", all(unix, target_arch = "x86_64"))))'.dependencies]
+[target.'cfg(not(any(target_os = "macos", all(unix, target_arch = "x86_64"), all(windows, target_env = "gnu"))))'.dependencies]
 katex = { version = "0.4.6", default-features = false, features = ["duktape"] }
 
 [profile.release]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -240,5 +240,5 @@ fn test_inline_rendering_w_custom_delimiter() {
     debug_assert_eq!(expected_output, rendered_content[0]);
 }
 
-#[cfg(any(target_os = "macos", all(unix, target_arch = "x86_64")))]
+#[cfg(any(target_os = "macos", all(unix, target_arch = "x86_64"), all(windows, target_env = "gnu")))]
 mod not_duktape;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -240,5 +240,9 @@ fn test_inline_rendering_w_custom_delimiter() {
     debug_assert_eq!(expected_output, rendered_content[0]);
 }
 
-#[cfg(any(target_os = "macos", all(unix, target_arch = "x86_64"), all(windows, target_env = "gnu")))]
+#[cfg(any(
+    target_os = "macos",
+    all(unix, target_arch = "x86_64"),
+    all(windows, target_env = "gnu")
+))]
 mod not_duktape;


### PR DESCRIPTION
- Cross build `x86_64-pc-windows-gnu` for
  - test build without run
  - deploy
  The build is, like in #64, statically linked to OpenSSL.
- Use default features of `katex` for `windows` `gnu` instead of `duktape`.