### PR TITLE
Allow no `[output.katex]`; Doc for `no-css` option for self-host CSS&fonts and say deprecate `static-css`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dd14596c0e5b954530d0e6f1fd99b89c03e313aa2086e8da4303701a09e1cf"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,11 +140,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.10"
+version = "4.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce38afc168d8665cfc75c7b1dd9672e50716a137f433f070991619744a67342a"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.1",
  "clap_lex",
  "is-terminal",
  "once_cell",
@@ -262,7 +268,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.0",
+ "syn 2.0.2",
 ]
 
 [[package]]
@@ -279,7 +285,7 @@ checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.0",
+ "syn 2.0.2",
 ]
 
 [[package]]
@@ -644,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -824,7 +830,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -849,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
+checksum = "0dd6da19f25979c7270e70fa95ab371ec3b701cd0eefc47667a09785b3c59155"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -866,9 +872,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -940,7 +946,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -1140,7 +1146,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1213,7 +1219,7 @@ version = "0.10.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1444,7 +1450,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -1504,7 +1510,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1569,11 +1575,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "2fe885c3a125aa45213b68cc1472a49880cb5923dc23f522ad2791b882228778"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1638,7 +1644,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1672,7 +1678,7 @@ checksum = "78997f4555c22a7971214540c4a661291970619afd56de19f77e0de86296e1e5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.0",
+ "syn 2.0.2",
 ]
 
 [[package]]
@@ -1822,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff13bb1732bccfe3b246f3fdb09edfd51c01d6f5299b7ccd9457c2e4e37774"
+checksum = "59d3276aee1fa0c33612917969b5172b5be2db051232a6e4826f1a1a9191b045"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1891,7 +1897,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.0",
+ "syn 2.0.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -19,20 +19,15 @@ First, install `mdbook-katex`
 - Windows users:
     The recommended way is to download the latest `x86_64-pc-windows-gnu.zip` from [Releases](https://github.com/lzanini/mdbook-katex/releases) for the full functionality. See [#67](https://github.com/lzanini/mdbook-katex/issues/67) for the reasons.
 
-Then, add the following lines to your `book.toml` file
+Then, add the following line to your `book.toml` file
 
 ```toml
-[output.katex]
-
-[output.html]
-
 [preprocessor.katex]
-renderers = ["html"]
 ```
 
 You can now use `$` and `$$` delimiters for inline and display equations within your `.md` files. If you need a regular dollar symbol, you can escape delimiters with a backslash `\$`.
 
-```
+```markdown
 # Chapter 1
 
 Here is an inline example, $ \pi(\theta) $, 
@@ -68,22 +63,40 @@ The currently supported arguments are:
 There are also options to configure the behaviour of the preprocessor:
 | Option | Default | Description |
 | :- | :- | :- |
-| `static-css` | `false` | Generates fully static html pages with katex styling |
+| `no-css` | `false` | Do not inject KaTeX stylesheet link (See [Self-host KaTeX CSS and fonts](#self-host-katex-css-and-fonts)) |
 | `macros` | `None` | Path to macros file (see [Custom macros](#custom-macros)) |
 | `include-src` | `false` | Include math expressions source code (See [Including math Source](#including-math-source)) |
 | `block-delimiter` | `{left = "$$", right = "$$"}` | See [Custom delimiter](#custom-delimiter) |
 | `inline-delimiter` | `{left = "$", right = "$"}` | See [Custom delimiter](#custom-delimiter) |
+| `static-css` | `false` | ([Deprecated](https://github.com/lzanini/mdbook-katex/issues/68)) Generates fully static html pages with katex styling |
 
 For example:
 
 ```toml
 [preprocessor.katex]
 renderers = ["html"]
-static-css = false
+no-css = false
 include-src = false
 block-delimiter = {left = "$$", right = "$$"}
 inline-delimiter = {left = "$", right = "$"}
 ```
+
+## Self-host KaTeX CSS and fonts
+
+KaTeX requires a stylesheet and fonts to render correctly.
+
+By default, `mdbook-katex` inject a KaTeX stylesheet link pointing to a CDN.
+
+If you want to self-host the CSS and fonts instead, you should specify in `book.toml`:
+
+```toml
+[preprocessor.katex]
+no-css = true
+```
+
+and manually add the CSS and fonts to your mdBook project before build.
+
+See [`mdbook-katex` Static CSS Example](https://github.com/SichangHe/mdbook_katex_static_css) for an automated example.
 
 ## Custom macros
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,7 @@ impl Renderer for KatexProcessor {
         "katex"
     }
 
-    fn render(&self, ctx: &RenderContext) -> Result<()> {
-        enforce_config(&ctx.config);
+    fn render(&self, _ctx: &RenderContext) -> Result<()> {
         Ok(())
     }
 }
@@ -202,10 +201,12 @@ impl Preprocessor for KatexProcessor {
 
     #[tokio::main]
     async fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book, Error> {
-        // enforce config requirements
-        enforce_config(&ctx.config);
         // parse TOML config
         let cfg = get_config(&ctx.config)?;
+        if cfg.static_css {
+            // enforce config requirements
+            enforce_config(&ctx.config);
+        }
         let (inline_opts, display_opts, extra_opts) = cfg.build_opts(&ctx.root);
         // get stylesheet header
         let (stylesheet_header, maybe_download_task) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use mdbook::book::{Book, BookItem};
 use mdbook::errors::Error;
 use mdbook::errors::Result;
 use mdbook::preprocess::{Preprocessor, PreprocessorContext};
-use mdbook::renderer::{RenderContext, Renderer};
+
 use mdbook::utils::fs::path_to_root;
 use tokio::spawn;
 use tokio::task::JoinHandle;
@@ -180,18 +180,6 @@ fn enforce_config(cfg: &mdbook::Config) {
 }
 
 pub struct KatexProcessor;
-
-// dummy renderer to ensure rendered output is always located
-// in the `book/html/` directory
-impl Renderer for KatexProcessor {
-    fn name(&self) -> &str {
-        "katex"
-    }
-
-    fn render(&self, _ctx: &RenderContext) -> Result<()> {
-        Ok(())
-    }
-}
 
 // preprocessor to inject rendered katex blocks and stylesheet
 impl Preprocessor for KatexProcessor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{crate_version, Arg, ArgMatches, Command};
 use mdbook::book::Book;
 use mdbook::errors::Error;
 use mdbook::preprocess::{CmdPreprocessor, Preprocessor, PreprocessorContext};
-use mdbook::renderer::{RenderContext, Renderer};
+use mdbook::renderer::RenderContext;
 use mdbook_katex::KatexProcessor;
 use std::io::{self, Read};
 
@@ -56,10 +56,6 @@ fn handle_preprocessing(
     Ok(())
 }
 
-fn handle_rendering(ctx: &RenderContext, rend: &dyn Renderer) -> Result<(), Error> {
-    rend.render(ctx)
-}
-
 fn main() -> Result<(), Error> {
     // set up app
     let matches = make_app().get_matches();
@@ -76,9 +72,10 @@ fn main() -> Result<(), Error> {
     } else if let Ok((ctx, book)) = CmdPreprocessor::parse_input(book_data.as_bytes()) {
         // handle preprocessing
         return handle_preprocessing(&pre, &ctx, &book);
-    } else if let Ok(ctx) = RenderContext::from_json(book_data.as_bytes()) {
-        // handle rendering
-        return handle_rendering(&ctx, &pre);
+    }
+    // Fake rendering to support `[output.katex]`.
+    else if RenderContext::from_json(book_data.as_bytes()).is_ok() {
+        return Ok(());
     }
 
     Err(Error::msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ fn handle_preprocessing(
 }
 
 fn handle_rendering(ctx: &RenderContext, rend: &dyn Renderer) -> Result<(), Error> {
-    check_mdbook_version(&ctx.version);
     rend.render(ctx)
 }
 


### PR DESCRIPTION
Half-way addressing #68.
- Only require `[output.katex]` if `static-css = true`.
- Only one warning message about mdBook version mismatch.
- `no-css` option: simply not inject stylesheet link header. This is introduced so users can manually include CSS and fonts following mdBook `additional-css` rules and rules including fonts.
- Encourage users to use `no-css` and deprecate `static-css`.